### PR TITLE
POOL_SIZE added

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ Assuming you have Django installed and this app installed,
 
 3. Set POOL_SIZE to 100 or so in your db settings and tweak this number so that each worker process has adequate postgres connections available to it.  If you have four worker processes and max_connections for postgres is 101, then 25 is a reasonable pool size that will still let you run manage commands like south.  Each connection to postgres will fork a postgres worker, visible running 'pstree -pa' on Linux systems.  Raising max_connections in postgres can consume a lot of memory if work_mem is set high.  Work_mem is necessary to do in-memory sorts before spilling to the disk, so don't set this too low just to have tons of postgres threads running.
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django_psycopg2_pool.gevent', 
-        'NAME': 'myproject_db',                  
-        'USER': 'myproject',                    
-        'PASSWORD': 'mypassword',                
-        'HOST': '/var/run/postgresql',           # When running postgres on unix socket
-        'PORT': '',                              # Empty if using unix socket
-        'POOL_SIZE' : 20,                        # slightly less than max_connections / 4
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django_psycopg2_pool.gevent', 
+            'NAME': 'myproject_db',                  
+            'USER': 'myproject',                    
+            'PASSWORD': 'mypassword',                
+            'HOST': '/var/run/postgresql',           # When running postgres on unix socket
+            'PORT': '',                              # Empty if using unix socket
+            'POOL_SIZE' : 20,                        # slightly less than max_connections / 4
+        }
     }
-}
 
 ## NOTES
 ---------

--- a/README.md
+++ b/README.md
@@ -20,15 +20,26 @@ OR
 
 Assuming you have Django installed and this app installed,
 
-1. add 'django-psycopg2-pool.gevent' as your db backend
+1. set ENGINE to 'django-psycopg2-pool.gevent' in your db backend settings
 2. this may be required if you have south: in settings.py, have a line like:
 
     SOUTH_DATABASE_ADAPTERS = {
         'default': "south.db.postgresql_psycopg2",
     }
 
-3. add ''POOL_SIZE' : 100,' to your db backend options and tweak this number so that each worker process has adequate postgres connections available to it.  Each connection to postgres will fork a postgres worker, visible running 'pstree -pa' on Linux systems.  Raising max_connections in postgres can consume a lot of memory if work_mem is set high.  Work_mem is necessary to do in-memory sorts before spilling to the disk, so don't set this too low just to have tons of postgres threads running.
+3. Set POOL_SIZE to 100 or so in your db settings and tweak this number so that each worker process has adequate postgres connections available to it.  If you have four worker processes and max_connections for postgres is 101, then 25 is a reasonable pool size that will still let you run manage commands like south.  Each connection to postgres will fork a postgres worker, visible running 'pstree -pa' on Linux systems.  Raising max_connections in postgres can consume a lot of memory if work_mem is set high.  Work_mem is necessary to do in-memory sorts before spilling to the disk, so don't set this too low just to have tons of postgres threads running.
 
+DATABASES = {
+    'default': {
+        'ENGINE': 'django_psycopg2_pool.gevent', 
+        'NAME': 'myproject_db',                  
+        'USER': 'myproject',                    
+        'PASSWORD': 'mypassword',                
+        'HOST': '/var/run/postgresql',           # When running postgres on unix socket
+        'PORT': '',                              # Empty if using unix socket
+        'POOL_SIZE' : 20,                        # slightly less than max_connections / 4
+    }
+}
 
 ## NOTES
 ---------

--- a/README.md
+++ b/README.md
@@ -20,15 +20,17 @@ OR
 
 Assuming you have Django installed and this app installed,
 
-1. set ENGINE to 'django-psycopg2-pool.gevent' in your db backend settings
+1. set `ENGINE` to `'django-psycopg2-pool.gevent'` in your db backend settings
 2. this may be required if you have south: in settings.py, have a line like:
 
+<!-- language: python -->
     SOUTH_DATABASE_ADAPTERS = {
         'default': "south.db.postgresql_psycopg2",
     }
 
-3. Set POOL_SIZE to 100 or so in your db settings and tweak this number so that each worker process has adequate postgres connections available to it.  If you have four worker processes and max_connections for postgres is 101, then 25 is a reasonable pool size that will still let you run manage commands like south.  Each connection to postgres will fork a postgres worker, visible running 'pstree -pa' on Linux systems.  Raising max_connections in postgres can consume a lot of memory if work_mem is set high.  Work_mem is necessary to do in-memory sorts before spilling to the disk, so don't set this too low just to have tons of postgres threads running.
+3. Set `POOL_SIZE` to 100 or so in your db settings and tweak this number so that each worker process has adequate postgres connections available to it.  If you have four worker processes and `max_connections` for postgres is 101, then 25 is a reasonable pool size that will still let you run manage commands like south.  Each connection to postgres will fork a postgres worker, visible running `pstree -pa` on Linux systems.  Raising `max_connections` in postgres can consume a lot of memory if `work_mem` is set high.  Work_mem is necessary to do in-memory sorts before spilling to the disk, so don't set this too low just to have tons of postgres threads running.
 
+<!-- language: python -->
     DATABASES = {
         'default': {
             'ENGINE': 'django_psycopg2_pool.gevent', 
@@ -37,7 +39,7 @@ Assuming you have Django installed and this app installed,
             'PASSWORD': 'mypassword',                
             'HOST': '/var/run/postgresql',           # When running postgres on unix socket
             'PORT': '',                              # Empty if using unix socket
-            'POOL_SIZE' : 20,                        # slightly less than max_connections / 4
+            'POOL_SIZE' : 20,                        # slightly less than postgres max_connections / worker processes
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Assuming you have Django installed and this app installed,
         'default': "south.db.postgresql_psycopg2",
     }
 
+3. add ''POOL_SIZE' : 100,' to your db backend options and tweak this number so that each worker process has adequate postgres connections available to it.  Each connection to postgres will fork a postgres worker, visible running 'pstree -pa' on Linux systems.  Raising max_connections in postgres can consume a lot of memory if work_mem is set high.  Work_mem is necessary to do in-memory sorts before spilling to the disk, so don't set this too low just to have tons of postgres threads running.
+
 
 ## NOTES
 ---------

--- a/django_psycopg2_pool/gevent/base.py
+++ b/django_psycopg2_pool/gevent/base.py
@@ -127,7 +127,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self._pg_version = None
         self.conn_params = self._conn_params()
         if self.alias not in POOLS:
-            self.pool = POOLS[self.alias] = PostgresConnectionPool(maxsize=1000, **self.conn_params)
+            pool_size = 1000 if 'POOL_SIZE' not in self.settings_dict.keys() else self.settings_dict['POOL_SIZE']
+            self.pool = POOLS[self.alias] = PostgresConnectionPool(maxsize=pool_size, **self.conn_params)
         else:
             self.pool = POOLS[self.alias]
 

--- a/django_psycopg2_pool/gevent/base.py
+++ b/django_psycopg2_pool/gevent/base.py
@@ -127,7 +127,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self._pg_version = None
         self.conn_params = self._conn_params()
         if self.alias not in POOLS:
-            pool_size = 1000 if 'POOL_SIZE' not in self.settings_dict.keys() else self.settings_dict['POOL_SIZE']
+            pool_size = 1000 if 'POOL_SIZE' not in self.settings_dict.keys() else int(self.settings_dict['POOL_SIZE'])
             self.pool = POOLS[self.alias] = PostgresConnectionPool(maxsize=pool_size, **self.conn_params)
         else:
             self.pool = POOLS[self.alias]


### PR DESCRIPTION
Backend will try to read POOL_SIZE from the database settings before using the old default of 1000, which is really high for some machines without a lot of work_mem and max_connections tuning.
